### PR TITLE
Initial implementation of Mayhem integration

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,61 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  MAYHEMFILE: Mayhem/smallvec_ops.mayhemfile
+  PROJECTNAME: rust-smallvec
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis of smallvec_ops
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,21 @@
+# Use the example in Mayhem Docs as an example/starting point
+FROM rust:1.60-buster as rust-builder
+RUN cargo install afl
+
+# Add the source code to the image and build the target
+ADD . /rust-smallvec
+WORKDIR /rust-smallvec/fuzz
+RUN cargo afl build --release --bin smallvec_ops --features afl
+# Built target is in /rust-smallvec/fuzz/target/release/
+
+# To simplify matters, we'll copy the compiled target as well as
+# the fuzz input folder to a new image with AFL
+FROM --platform=linux/amd64 rust:1.60-buster
+RUN cargo install afl
+
+# Copy the compiled target and the input cases
+COPY --from=rust-builder /rust-smallvec/fuzz/target/release/smallvec_ops /rust-smallvec/fuzz/in /
+
+# Set to fuzz!
+ENTRYPOINT ["cargo", "afl", "fuzz", "-i", "/in", "-o", "/out"]
+CMD ["/smallvec_ops"]

--- a/Mayhem/smallvec_ops.mayhemfile
+++ b/Mayhem/smallvec_ops.mayhemfile
@@ -1,0 +1,9 @@
+project: rust-smallvec
+target: smallvec_ops
+duration: 300
+
+cmds:
+  - cmd: /smallvec_ops
+    env:
+      DISABLE_SMOKETEST: '1'
+    afl: true


### PR DESCRIPTION
Implementation of Mayhem integration for `rust-smallvec`. This integration was straightforward, as AFL fuzzing binaries already existed for the project. A `Dockerfile`, `Mayhemfile`, and YAML file detailing the Mayhem GitHub action were added. Due to issues with other AFL binaries for Rust, smoketesting in Mayhem was disabled. However, smoketesting may not cause a problem for this repository (it was not tested).